### PR TITLE
Add Github Workflow and README.md

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,4 +1,4 @@
-name: Libogc2 build
+name: libogc2 build
 
 on: [push, pull_request]
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,18 @@
+name: Libogc2 build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build libogc2
+    runs-on: ubuntu-20.04
+    container: devkitpro/devkitppc:latest
+ 
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Build libogc2
+      run: |
+        make -j2

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+## Libogc2
+
+### Build status
+
+|Continuous integration: 	| [![Build Status][Build]][Actions] 
+|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+
+[Actions]: https://github.com/extremscorner/libogc2/actions
+[Build]: https://github.com/extremscorner/libogc2/workflows/Libogc2%20Build/badge.svg

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-## Libogc2
+## libogc2
 
 ### Build status
 
-|Continuous integration: 	| [![Build Status][Build]][Actions] 
+|Continuous integration: 	| [![Build status][Build]][Actions] 
 |-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 
 [Actions]: https://github.com/extremscorner/libogc2/actions
-[Build]: https://github.com/extremscorner/libogc2/workflows/Libogc2%20Build/badge.svg
+[Build]: https://github.com/extremscorner/libogc2/workflows/libogc2%20build/badge.svg


### PR DESCRIPTION
I've added a Github Workflow which will start a hosted runner to compile the build when someone opens a PR or code is added to the master. Here you can see how that will look: https://github.com/bladeoner/libogc2/actions

I also added a README.md which provides the status of this the build, on the following page is how it will look.
https://github.com/bladeoner/libogc2/tree/workflow

On the README.md page you cannot see the status of the build yet, that will been shown after the first succesful build.