### PR TITLE
Add Nightly builds

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -13,6 +13,13 @@ jobs:
       with:
         submodules: true
 
-    - name: Build libogc2
+    - name: Build libogc2 artifacts
       run: |
-        make -j2
+        make install -j2
+         
+    - name: Upload libogc2 artifacts
+      uses: actions/upload-artifact@v2
+      with: 
+        name: libogc2
+        path: |
+         /opt/devkitpro/libogc2/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## libogc2
 
-### Build status
+### Nightly builds
 
-|Continuous integration: 	| [![Build status][Build]][Actions] 
+|Download nightly builds from continuous integration: 	| [![Build Status][Build]][Actions]
 |-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 
 [Actions]: https://github.com/extremscorner/libogc2/actions


### PR DESCRIPTION
This PR will make Nightly builds available for download.

When you click on "libogc build - passing", click on the latest workflow run name, the artifacts will be available for download.