### PR TITLE
Enable DVD DTK audio streaming

### DIFF
--- a/gc/ogc/dvd.h
+++ b/gc/ogc/dvd.h
@@ -358,6 +358,8 @@ s32 DVD_ReadAbsAsyncForBS(dvdcmdblk *block,void *buf,u32 len,s64 offset,dvdcbcal
 s32 DVD_SeekPrio(dvdcmdblk *block,s64 offset,s32 prio);
 s32 DVD_SeekAbsAsyncPrio(dvdcmdblk *block,s64 offset,dvdcbcallback cb,s32 prio);
 s32 DVD_CancelAllAsync(dvdcbcallback cb);
+s32 DVD_PrepareStreamAbsAsync(dvdcmdblk *block,u32 len,s64 offset,dvdcbcallback cb);
+s32 DVD_PrepareStreamAbs(dvdcmdblk *block,u32 len,s64 offset);
 s32 DVD_StopStreamAtEndAsync(dvdcmdblk *block,dvdcbcallback cb);
 s32 DVD_StopStreamAtEnd(dvdcmdblk *block);
 s32 DVD_ReadDiskID(dvdcmdblk *block,dvddiskid *id,dvdcbcallback cb);

--- a/libogc/dvd.c
+++ b/libogc/dvd.c
@@ -2519,12 +2519,12 @@ s32 DVD_CancelAllAsync(dvdcbcallback cb)
 }
 
 s32 DVD_PrepareStreamAbsAsync(dvdcmdblk* cmd, u32 length, u32 offset, dvdcbcallback callback) {
-    cmd->cmd = 6;
-    cmd->len = length;
-    cmd->offset = offset;
-    cmd->cb = callback;
+	cmd->cmd = 6;
+	cmd->len = length;
+	cmd->offset = offset;
+	cmd->cb = callback;
 
-    return __issuecommand(1, cmd);
+	return __issuecommand(1, cmd);
 }
 
 s32 DVD_PrepareStream(dvdfileinfo* fileInfo, u32 length, u32 offset) {
@@ -2536,28 +2536,28 @@ s32 DVD_PrepareStream(dvdfileinfo* fileInfo, u32 length, u32 offset) {
 	printf("DVD_PrepareStream(%p)\n",block);
 #endif
 
-    u32 start = fileInfo->addr + offset;
+	u32 start = fileInfo->addr + offset;
 
-    if (!is_aligned_32k(start)) {
+	if (!is_aligned_32k(start)) {
 #ifdef _DVD_DEBUG
-        printf("DVD_PrepareStream(): Specified start address (filestart(0x%x) + offset(0x%x)) is not 32KB aligned\n", fileInfo->addr, offset);
+		printf("DVD_PrepareStream(): Specified start address (filestart(0x%x) + offset(0x%x)) is not 32KB aligned\n", fileInfo->addr, offset);
 #endif
-        return DVD_ERROR_FATAL;
-    }
+		return DVD_ERROR_FATAL;
+	}
 
-    if (length == 0)
-        length = fileInfo->len - offset;
+	if (length == 0)
+		length = fileInfo->len - offset;
 
-    if (!is_aligned_32k(length)) {
+	if (!is_aligned_32k(length)) {
 #ifdef _DVD_DEBUG
-        printf("DVD_PrepareStream(): Specified length (0x%x) is not a multiple of 32768(32*1024)\n", length);
+		printf("DVD_PrepareStream(): Specified length (0x%x) is not a multiple of 32768(32*1024)\n", length);
 #endif
-        return DVD_ERROR_FATAL;
-    }
+		return DVD_ERROR_FATAL;
+	}
 
-    if (!((offset <= fileInfo->len) && (offset + length <= fileInfo->len))) {
+	if (!((offset <= fileInfo->len) && (offset + length <= fileInfo->len))) {
 #ifdef _DVD_DEBUG
-        printf("DVD_PrepareStream(): The area specified (offset(0x%x), length(0x%x)) is out of the file\n", offset, length);
+		printf("DVD_PrepareStream(): The area specified (offset(0x%x), length(0x%x)) is out of the file\n", offset, length);
 #endif
 		return DVD_ERROR_FATAL;
 	}
@@ -2575,7 +2575,7 @@ s32 DVD_PrepareStream(dvdfileinfo* fileInfo, u32 length, u32 offset) {
 	} while(state!=DVD_STATE_END && state!=DVD_STATE_FATAL_ERROR && state!=DVD_STATE_CANCELED);
 	_CPU_ISR_Restore(level);
 
-    return ret;
+	return ret;
 }
 
 s32 DVD_StopStreamAtEndAsync(dvdcmdblk *block,dvdcbcallback cb)

--- a/libogc/dvd.c
+++ b/libogc/dvd.c
@@ -135,7 +135,6 @@ distribution.
 
 #define cpu_to_le32(x)					(((x>>24)&0x000000ff) | ((x>>8)&0x0000ff00) | ((x<<8)&0x00ff0000) | ((x<<24)&0xff000000))
 #define dvd_may_retry(s)				(DVD_STATUS(s) == DVD_STATUS_READY || DVD_STATUS(s) == DVD_STATUS_DISK_ID_NOT_READ)
-#define is_aligned_32k(x)				(((u32)(x) & (32 * 1024 - 1)) == 0)
 
 #define _SHIFTL(v, s, w)	\
     ((u32) (((u32)(v) & ((0x01 << (w)) - 1)) << (s)))
@@ -2518,51 +2517,29 @@ s32 DVD_CancelAllAsync(dvdcbcallback cb)
 	return 1;
 }
 
-s32 DVD_PrepareStreamAbsAsync(dvdcmdblk* cmd, u32 length, u32 offset, dvdcbcallback callback) {
-	cmd->cmd = 6;
-	cmd->len = length;
-	cmd->offset = offset;
-	cmd->cb = callback;
+s32 DVD_PrepareStreamAbsAsync(dvdcmdblk *block,u32 len,s64 offset,dvdcbcallback cb)
+{
+#ifdef _DVD_DEBUG
+	printf("DVD_PrepareStreamAbsAsync(%p,%d,%d,%p)\n",block,len,offset,cb);
+#endif
+	if((len&0x7fff) || (offset&0x7fff)) return 0;
 
-	return __issuecommand(1, cmd);
+	block->cmd = 0x0006;
+	block->len = len;
+	block->offset = offset;
+	block->cb = cb;
+
+	return __issuecommand(1,block);
 }
 
-s32 DVD_PrepareStream(dvdfileinfo* fileInfo, u32 length, u32 offset) {
+s32 DVD_PrepareStreamAbs(dvdcmdblk *block,u32 len,s64 offset)
+{
 	s32 ret,state;
 	u32 level;
-
-	dvdcmdblk *block = &(fileInfo->block);
 #ifdef _DVD_DEBUG
-	printf("DVD_PrepareStream(%p)\n",block);
+	printf("DVD_PrepareStreamAbs(%p,%d,%d)\n",block,len,offset);
 #endif
-
-	u32 start = fileInfo->addr + offset;
-
-	if (!is_aligned_32k(start)) {
-#ifdef _DVD_DEBUG
-		printf("DVD_PrepareStream(): Specified start address (filestart(0x%x) + offset(0x%x)) is not 32KB aligned\n", fileInfo->addr, offset);
-#endif
-		return DVD_ERROR_FATAL;
-	}
-
-	if (length == 0)
-		length = fileInfo->len - offset;
-
-	if (!is_aligned_32k(length)) {
-#ifdef _DVD_DEBUG
-		printf("DVD_PrepareStream(): Specified length (0x%x) is not a multiple of 32768(32*1024)\n", length);
-#endif
-		return DVD_ERROR_FATAL;
-	}
-
-	if (!((offset <= fileInfo->len) && (offset + length <= fileInfo->len))) {
-#ifdef _DVD_DEBUG
-		printf("DVD_PrepareStream(): The area specified (offset(0x%x), length(0x%x)) is out of the file\n", offset, length);
-#endif
-		return DVD_ERROR_FATAL;
-	}
-
-	ret = DVD_PrepareStreamAbsAsync(block, length, start, __dvd_synccb);
+	ret = DVD_PrepareStreamAbsAsync(block,len,offset,__dvd_synccb);
 	if(!ret) return DVD_ERROR_FATAL;
 
 	_CPU_ISR_Disable(level);


### PR DESCRIPTION
Based on code reversed from Metroid Prime
https://github.com/PrimeDecomp/prime/blob/0c302d2c554666cdcab303017c0ae5fca98fea32/src/Dolphin/dvd/dvdfs.c#L541-L567

This also has some alignment checks... I used a macro but I'd be happy to change these to an inline `offset & 0x7fff`

I'll also post a working example in the discussion which can be copied to gamecube-examples