### PR TITLE
Support Force Feedback Wheel

### DIFF
--- a/include/ogc/pad.h
+++ b/include/ogc/pad.h
@@ -19,6 +19,9 @@
 #define PAD_MOTOR_RUMBLE			1
 #define PAD_MOTOR_STOP_HARD			2
 
+#define PAD_FORCE_ON				3
+#define PAD_FORCE_OFF				2
+
 #define PAD_ERR_NONE				0
 #define PAD_ERR_NO_CONTROLLER		-1
 #define PAD_ERR_NOT_READY			-2
@@ -31,6 +34,7 @@
 #define PAD_TRIGGER_Z				0x0010
 #define PAD_TRIGGER_R				0x0020
 #define PAD_TRIGGER_L				0x0040
+#define PAD_PEDAL_CONNECT			0x0080
 #define PAD_BUTTON_A				0x0100
 #define PAD_BUTTON_B				0x0200
 #define PAD_BUTTON_X				0x0400
@@ -48,8 +52,16 @@ typedef struct _padstatus {
 	u16 button;
 	s8 stickX;
 	s8 stickY;
-	s8 substickX;
-	s8 substickY;
+	union {
+		struct {
+			s8 substickX;
+			s8 substickY;
+		};
+		struct {
+			s8 gas;
+			s8 brake;
+		};
+	};
 	u8 triggerL;
 	u8 triggerR;
 	u8 analogA;
@@ -95,6 +107,9 @@ u8 PAD_TriggerR(s32 chan);
 
 u8 PAD_AnalogA(s32 chan);
 u8 PAD_AnalogB(s32 chan);
+
+#define PAD_Gas(chan) PAD_SubStickX(chan)
+#define PAD_Brake(chan) PAD_SubStickY(chan)
 
 sampling_callback PAD_SetSamplingCallback(sampling_callback cb);
 

--- a/include/ogc/pad.h
+++ b/include/ogc/pad.h
@@ -52,16 +52,8 @@ typedef struct _padstatus {
 	u16 button;
 	s8 stickX;
 	s8 stickY;
-	union {
-		struct {
-			s8 substickX;
-			s8 substickY;
-		};
-		struct {
-			s8 gas;
-			s8 brake;
-		};
-	};
+	s8 substickX;
+	s8 substickY;
 	u8 triggerL;
 	u8 triggerR;
 	u8 analogA;
@@ -107,9 +99,6 @@ u8 PAD_TriggerR(s32 chan);
 
 u8 PAD_AnalogA(s32 chan);
 u8 PAD_AnalogB(s32 chan);
-
-#define PAD_Gas(chan) PAD_SubStickX(chan)
-#define PAD_Brake(chan) PAD_SubStickY(chan)
 
 sampling_callback PAD_SetSamplingCallback(sampling_callback cb);
 


### PR DESCRIPTION
Adds support for the official Speed Force racing wheel, sold by Logitech. The Speed Force wheel is largely a standard GameCube controller, abeit with a different ID, support for simple force feedback commands, gas/brake instead of the C Stick, and using the status bit presumably for the nonexistent ZL Button to determine if the pedals are connected or not.

libogc/2 has a strict filter on what Joybus IDs are valid, this loosens it up a bit to allow the wheel and keyboard to pass the first check (any of SI_TYPE_GC not including SI_GC_RECEIVER). Other GC accessories already pass this check.

PAD_ControlForce() has been added, with similar implementation to PAD_ControlMotor(). Aliases are added so developers may use `gas` & `brake` to refer to the pedals.