### PR TITLE
Fix Motion Plus detection — 4 bugs fixed in motion_plus.c + public WPAD_HasMotionPlus API

### DIFF
--- a/wiiuse/motion_plus.c
+++ b/wiiuse/motion_plus.c
@@ -7,13 +7,15 @@
 	#include <Winsock2.h>
 #endif
 
+#include <lwp_wkspace.inl>
+
 #include "definitions.h"
 #include "wiiuse_internal.h"
 #include "dynamics.h"
 #include "events.h"
 #include "wiiboard.h"
 #include "io.h"
-#include "lwp_wkspace.h"
+
 #include "motion_plus.h"
 
 static void wiiuse_probe_motion_plus_check2(struct wiimote_t *wm, ubyte *data, uword len)
@@ -28,7 +30,7 @@ static void wiiuse_probe_motion_plus_check2(struct wiimote_t *wm, ubyte *data, u
 
 static void wiiuse_probe_motion_plus_check1(struct wiimote_t *wm, ubyte *data, uword len)
 {
-	if (data[1] != 0x05)
+	if (data[5] != 0x05)
 	{
 		WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_MPLUS_PRESENT);
 		WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_EXP_HANDSHAKE);
@@ -43,7 +45,7 @@ static void wiiuse_probe_motion_plus_check1(struct wiimote_t *wm, ubyte *data, u
 void wiiuse_probe_motion_plus(struct wiimote_t *wm)
 {
 	ubyte *buf = __lwp_wkspace_allocate(MAX_PAYLOAD);
-	wiiuse_read_data(wm, buf, WM_EXP_MOTION_PLUS_MODE, 2, wiiuse_probe_motion_plus_check1);
+	wiiuse_read_data(wm, buf, WM_EXP_ID, 6, wiiuse_probe_motion_plus_check1);
 }
 
 void wiiuse_motion_plus_check(struct wiimote_t *wm,ubyte *data,uword len)

--- a/wiiuse/wpad.c
+++ b/wiiuse/wpad.c
@@ -2,11 +2,11 @@
 
 wpad.c -- Wiimote Application Programmers Interface
 
-Copyright (C) 2008 - 2025
+Copyright (C) 2008-2025
 Michael Wiedenbauer (shagkur)
 Dave Murphy (WinterMute)
 Hector Martin (marcan)
-Extrems' Corner.org
+Zarithya
 
 This software is provided 'as-is', without any express or implied
 warranty.  In no event will the authors be held liable for any
@@ -46,16 +46,13 @@ distribution.
 #include "wiiboard.h"
 #include "wiiuse_internal.h"
 #include "wiiuse/wpad.h"
-#include "lwp_threads.h"
+
 #include "ogcsys.h"
 
-#define MAX_STREAMDATA_LEN			20
-#define EVENTQUEUE_LENGTH			16
+#define MAX_STREAMDATA_LEN				20
+#define EVENTQUEUE_LENGTH				16
 
-#define DISCONNECT_BATTERY_DIED		0x14
-#define DISCONNECT_POWER_OFF		0x15
-
-struct _wpad_thresh{
+struct _wpad_thresh {
 	s32 btns;
 	s32 ir;
 	s32 js;
@@ -88,27 +85,40 @@ struct _wpad_cb {
 
 static syswd_t __wpad_timer;
 static vu32 __wpads_inited = 0;
-static vs32 __wpads_ponded = 0;
+static vs32 __wpads_bonded = 0;
 static u32 __wpad_idletimeout = 300;
 static vu32 __wpads_active = 0;
 static vu32 __wpads_used = 0;
-static wiimote **__wpads = NULL;
-static wiimote_listen __wpads_listen[CONF_PAD_MAX_REGISTERED];
-static WPADData wpaddata[WPAD_MAX_WIIMOTES];
-static struct _wpad_cb __wpdcb[WPAD_MAX_WIIMOTES];
-static conf_pads __wpad_devs;
-static struct linkkey_info __wpad_keys[WPAD_MAX_WIIMOTES];
+wiimote **__wpads = NULL;
+static wiimote_listen __wpads_listen[WPAD_MAX_DEVICES] = {0};
+static WPADData wpaddata[WPAD_MAX_DEVICES] = {0};
+static struct _wpad_cb __wpdcb[WPAD_MAX_DEVICES] = {0};
+static conf_pads __wpad_devs = {0};
+static conf_pad_guests __wpad_guests = {0};
+static struct linkkey_info __wpad_keys[CONF_PAD_MAX_REGISTERED] = {0};
+static struct linkkey_info __wpad_guest_keys[CONF_PAD_ACTIVE_AND_OTHER] = {0};
+
+static sem_t __wpad_confsave_sem;
+static bool __wpad_confsave_thread_running = false;
+static void* __wpad_confsave_thread_func(void *);
+static lwp_t __wpad_confsave_thread = LWP_THREAD_NULL;
 
 static s32 __wpad_onreset(s32 final);
 static s32 __wpad_disconnect(struct _wpad_cb *wpdcb);
 static void __wpad_eventCB(struct wiimote_t *wm,s32 event);
 
+static s32 GetGuestSlot(struct bd_addr *pad_addr);
+static s32 GetRegisteredSlot(struct bd_addr *pad_addr);
+
 static void __wpad_def_powcb(s32 chan);
+static void __wpad_def_hostsynccb(u32 held);
 static WPADShutdownCallback __wpad_batcb = NULL;
 static WPADShutdownCallback __wpad_powcb = __wpad_def_powcb;
+static WPADDisconnectCallback __wpad_disconncb = NULL;
+static WPADHostSyncBtnCallback __wpad_hostsynccb = __wpad_def_hostsynccb;
+static WPADStatusCallback __wpad_statuscb = NULL;
 
 extern void __wiiuse_sensorbar_enable(int enable);
-extern void __SYS_DoPowerCB(void);
 
 static sys_resetinfo __wpad_resetinfo = {
 	{},
@@ -118,16 +128,50 @@ static sys_resetinfo __wpad_resetinfo = {
 
 static s32 __wpad_onreset(s32 final)
 {
-	//printf("__wpad_onreset(%d)\n",final);
+	WIIUSE_DEBUG("__wpad_onreset(%d)",final);
 	if(final==FALSE) {
 		WPAD_Shutdown();
 	}
 	return 1;
 }
 
+u32 __WPADClearActiveList(void)
+{
+	u32 level,ret;
+	
+	_CPU_ISR_Disable(level);
+
+	if(CONF_GetPadDevices(&__wpad_devs) < 0) {
+		ret = 1;
+		goto err;
+	}
+
+	__wpads_active = 0;
+	__wpads_used = 0;
+	memset(__wpad_devs.active,0,sizeof(__wpad_devs.active));
+	memset(&__wpad_guests,0,sizeof(__wpad_guests));
+	memset(__wpad_guest_keys,0,sizeof(__wpad_guest_keys));
+
+	if(CONF_SetPadDevices(&__wpad_devs) < 0) {
+		ret = 1;
+		goto err;
+	}
+
+	if(CONF_SetPadGuestDevices(&__wpad_guests) < 0) {
+		ret = 1;
+		goto err;
+	}
+
+	ret = CONF_SaveChanges();
+
+err:
+	_CPU_ISR_Restore(level);
+	return ret;
+}
+
 static void __wpad_def_powcb(s32 chan)
 {
-	__SYS_DoPowerCB();
+	SYS_DoPowerCB();
 }
 
 static void __wpad_timeouthandler(syswd_t alarm,void *cbarg)
@@ -138,8 +182,7 @@ static void __wpad_timeouthandler(syswd_t alarm,void *cbarg)
 
 	if(!__wpads_active) return;
 
-	__lwp_thread_dispatchdisable();
-	for(i=0;i<WPAD_MAX_WIIMOTES;i++) {
+	for(i=0;i<WPAD_MAX_DEVICES;i++) {
 		wpdcb = &__wpdcb[i];
 		wm = wpdcb->wm;
 		if(wm && WIIMOTE_IS_SET(wm,WIIMOTE_STATE_CONNECTED)) {
@@ -150,7 +193,6 @@ static void __wpad_timeouthandler(syswd_t alarm,void *cbarg)
 			}
 		}
 	}
-	__lwp_thread_dispatchunnest();
 }
 
 static void __wpad_sounddata_alarmhandler(syswd_t alarm,void *cbarg)
@@ -200,103 +242,225 @@ static void __wpad_setfmt(s32 chan)
 	}
 }
 
-wiimote *__wpad_assign_slot(struct bd_addr *pad_addr)
+wiimote *__wpad_assign_slot(wiimote_listen *wml, u8 err)
 {
-    u32 i, level;
-    struct bd_addr bdaddr;
-    //printf("WPAD Assigning slot (active: 0x%02x)\n", __wpads_used);
-    _CPU_ISR_Disable(level);
+	u32 i, level;
 
-	// check for balance board
-	BD_ADDR(&(bdaddr),__wpad_devs.balance_board.bdaddr[5],__wpad_devs.balance_board.bdaddr[4],__wpad_devs.balance_board.bdaddr[3],__wpad_devs.balance_board.bdaddr[2],__wpad_devs.balance_board.bdaddr[1],__wpad_devs.balance_board.bdaddr[0]);
-	if(bd_addr_cmp(pad_addr,&bdaddr)) {
-		if(!(__wpads_used&(1<<WPAD_BALANCE_BOARD))) {
-			__wpads_used |= (0x01<<WPAD_BALANCE_BOARD);
-			_CPU_ISR_Restore(level);
-			return __wpads[WPAD_BALANCE_BOARD];
-		} else {
-			_CPU_ISR_Restore(level);
-			return NULL;
+	_CPU_ISR_Disable(level);
+
+	for(i=0; i<WPAD_MAX_DEVICES; i++) {
+		if(wml == &__wpads_listen[i]) {
+			break;
 		}
 	}
 
-    // Try preassigned slots
-    for(i=0; i<CONF_PAD_MAX_ACTIVE /*&& i<WPAD_MAX_WIIMOTES*/; i++) {
-        BD_ADDR(&(bdaddr),__wpad_devs.active[i].bdaddr[5],__wpad_devs.active[i].bdaddr[4],__wpad_devs.active[i].bdaddr[3],__wpad_devs.active[i].bdaddr[2],__wpad_devs.active[i].bdaddr[1],__wpad_devs.active[i].bdaddr[0]);
-        if(bd_addr_cmp(pad_addr,&bdaddr) && !(__wpads_used & (1<<i))) {
-            //printf("WPAD Got Preassigned Slot %d\n", i);
-            __wpads_used |= (0x01<<i);
-            _CPU_ISR_Restore(level);
-            return __wpads[i];
-        }
-    }
+	if (i >= WPAD_MAX_DEVICES)
+	{
+		WIIUSE_ERROR("WPAD Slot %d Not Valid\n", i);
+		_CPU_ISR_Restore(level);
+		return NULL;
+	}
 
-    // No match, pick the first free slot
-    for(i=0; i<WPAD_MAX_WIIMOTES; i++) {
-        if(!(__wpads_used & (1<<i))) {
-            //printf("WPAD Got Free Slot %d\n", i);
-            __wpads_used |= (0x01<<i);
-            _CPU_ISR_Restore(level);
-            return __wpads[i];
-        }
-    }
-    //printf("WPAD All Slots Used\n");
-    _CPU_ISR_Restore(level);
-    return NULL;
+	if (err) {
+		WIIUSE_ERROR("WPAD Connection Error %d\n", (s8)err);
+		__wpads_used &= ~(0x01<<i);
+		_CPU_ISR_Restore(level);
+		return NULL;
+	}
+	
+	WIIUSE_DEBUG("WPAD Assigning Slot %d (used: 0x%02x)", i, __wpads_used);
+	if(i>=WPAD_BALANCE_BOARD) {
+		BYTES_FROM_BD_ADDR(__wpad_devs.balance_board.bdaddr, &wml->bdaddr);
+		memcpy(__wpad_devs.balance_board.name, wml->name, sizeof(__wpad_devs.balance_board.name));
+	} else {
+		BYTES_FROM_BD_ADDR(__wpad_devs.active[i].bdaddr, &wml->bdaddr);
+	}
+	LWP_SemPost(__wpad_confsave_sem);
+	_CPU_ISR_Restore(level);
+	return __wpads[i];
+}
+
+static void* __wpad_confsave_thread_func(void *)
+{
+	__wpad_confsave_thread_running = true;
+	
+	while (__wpad_confsave_thread_running)
+	{
+		CONF_SetPadDevices(&__wpad_devs);
+		CONF_SaveChanges();
+		LWP_SemWait(__wpad_confsave_sem);
+	}
+
+	return NULL;
+}
+
+static void __wpad_confsave_thread_stop(void)
+{
+	if (__wpad_confsave_sem != LWP_SEM_NULL) {
+		if (__wpad_confsave_thread != LWP_THREAD_NULL) {
+			__wpad_confsave_thread_running = false;
+			LWP_SemPost(__wpad_confsave_sem);
+			LWP_JoinThread(__wpad_confsave_thread, NULL);
+			__wpad_confsave_thread = LWP_THREAD_NULL;
+		}
+
+		LWP_SemDestroy(__wpad_confsave_sem);
+		__wpad_confsave_sem = LWP_SEM_NULL;
+	}
+}
+
+wiimote *__wpad_register_new(wiimote_listen *wml, u8 err)
+{
+	u32 i,j,level;
+	wiimote *wm;
+
+	int guestEntry = CONF_PAD_MAX_ACTIVE;
+	int registeredEntry = CONF_PAD_MAX_REGISTERED;
+
+	_CPU_ISR_Disable(level);
+	wm = __wpad_assign_slot(wml, err);
+	if (wm)
+	{
+		guestEntry = GetGuestSlot(&wml->bdaddr);
+		registeredEntry = GetRegisteredSlot(&wml->bdaddr);
+
+		if(BTE_GetPairMode() == PAIR_MODE_NORMAL) {
+			// Permanent pair, need to save bdaddr as known controller
+			if(registeredEntry >= __wpad_devs.num_registered) {
+				// If currently guest, we want to allow for upgrade to permanent pair
+				if(guestEntry < CONF_PAD_MAX_ACTIVE) {
+					// Wipe guest entry and shift later ones up
+					for(i = guestEntry; i < (__wpad_guests.num_guests - 1); i++) {
+						memcpy(&__wpad_guests.guests[i], &__wpad_guests.guests[i+1], sizeof(conf_pad_guest_device));
+					}
+					memset(&__wpad_guests.guests[--__wpad_guests.num_guests], 0, sizeof(conf_pad_guest_device));
+				}
+		
+				WIIUSE_DEBUG("Registering Wiimote '%s' with system...", wml->name);
+				memmove(&__wpad_devs.registered[1], &__wpad_devs.registered[0], sizeof(conf_pad_device)*(CONF_PAD_MAX_REGISTERED-1));
+				BYTES_FROM_BD_ADDR(__wpad_devs.registered[0].bdaddr, &wml->bdaddr);
+				memcpy(__wpad_devs.registered[0].name, wml->name, sizeof(__wpad_devs.registered[0].name));
+				if (__wpad_devs.num_registered < CONF_PAD_MAX_REGISTERED)
+					__wpad_devs.num_registered++;
+				LWP_SemPost(__wpad_confsave_sem);
+			}
+		} else if(registeredEntry >= CONF_PAD_MAX_REGISTERED) {
+			// Not permanent pair, need to save bdaddr and link key as guest controller
+			if(guestEntry >= CONF_PAD_MAX_ACTIVE) {
+				WIIUSE_DEBUG("Saving Wiimote '%s' as guest...", wml->name);
+				memmove(&__wpad_guests.guests[1], &__wpad_guests.guests[0], sizeof(conf_pad_guest_device)*(CONF_PAD_MAX_ACTIVE-1));
+				BYTES_FROM_BD_ADDR(__wpad_guests.guests[0].bdaddr, &wml->bdaddr);
+				memcpy(__wpad_guests.guests[0].name, wml->name, sizeof(__wpad_guests.guests[0].name));
+				if (__wpad_guests.num_guests < CONF_PAD_MAX_ACTIVE)
+					__wpad_guests.num_guests++;
+	
+				for(i=0; i<CONF_PAD_MAX_ACTIVE; i++) {
+					if(bd_addr_cmp(&wml->bdaddr,&__wpad_guest_keys[i].bdaddr)) {
+						u8 *src = __wpad_guest_keys[i].key;
+						u8 *dst = __wpad_guests.guests[0].link_key;
+						// Keys are stored in config backwards, like bdaddrs
+						for (j=0;j<BD_LINK_KEY_LEN;j++) {
+							dst[j] = src[BD_LINK_KEY_LEN - 1 - j];
+						}
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	_CPU_ISR_Restore(level);
+
+	return wm;
+}
+
+static s32 __wpad_setevtfilter_finished(s32 result,void *usrdata)
+{
+	u32 level;
+
+	WIIUSE_DEBUG("__wpad_setevtfilter_finished(%d)",result);
+
+	_CPU_ISR_Disable(level);
+	if((result==ERR_OK) && (__wpads_inited==WPAD_STATE_ENABLING)) {
+		__wpads_inited = WPAD_STATE_ENABLED;
+	}
+	_CPU_ISR_Restore(level);
+	return ERR_OK;
 }
 
 static s32 __wpad_init_finished(s32 result,void *usrdata)
 {
-	u32 i;
-	struct bd_addr bdaddr;
+	u32 level;
+	
+	WIIUSE_DEBUG("__wpad_init_finished(%d)",result);
 
-	//printf("__wpad_init_finished(%d)\n",result);
-
-	if(result==ERR_OK) {
-        for(i=0;/*__wpads[i] && */i<__wpad_devs.num_registered;i++) {
-            BD_ADDR(&(bdaddr),__wpad_devs.registered[i].bdaddr[5],__wpad_devs.registered[i].bdaddr[4],__wpad_devs.registered[i].bdaddr[3],__wpad_devs.registered[i].bdaddr[2],__wpad_devs.registered[i].bdaddr[1],__wpad_devs.registered[i].bdaddr[0]);
-            wiiuse_register(&__wpads_listen[i],&(bdaddr),__wpad_assign_slot);
-		}
-
-		BD_ADDR(&(bdaddr),__wpad_devs.balance_board.bdaddr[5],__wpad_devs.balance_board.bdaddr[4],__wpad_devs.balance_board.bdaddr[3],__wpad_devs.balance_board.bdaddr[2],__wpad_devs.balance_board.bdaddr[1],__wpad_devs.balance_board.bdaddr[0]);
-		if(i<CONF_PAD_MAX_REGISTERED && !bd_addr_cmp(&bdaddr,BD_ADDR_ANY)) {
-			wiiuse_register(&__wpads_listen[i],&(bdaddr),__wpad_assign_slot);
-		}
-		__wpads_inited = WPAD_STATE_ENABLED;
+	_CPU_ISR_Disable(level);
+	if(__wpads_inited==WPAD_STATE_ENABLING) {
+		BTE_SetEvtFilter(0x01,0x00,NULL,__wpad_setevtfilter_finished);
 	}
+	_CPU_ISR_Restore(level);
 	return ERR_OK;
 }
 
 static s32 __wpad_patch_finished(s32 result,void *usrdata)
 {
-	//printf("__wpad_patch_finished(%d)\n",result);
-	BTE_InitSub(__wpad_init_finished);
+	u32 level;
+	
+	WIIUSE_DEBUG("__wpad_patch_finished(%d)",result);
+
+	_CPU_ISR_Disable(level);
+	if(__wpads_inited==WPAD_STATE_ENABLING) {
+		BTE_InitSub(__wpad_init_finished);
+	}
+	_CPU_ISR_Restore(level);
 	return ERR_OK;
 }
 
 static s32 __readlinkkey_finished(s32 result,void *usrdata)
 {
-	//printf("__readlinkkey_finished(%d)\n",result);
-
-	__wpads_ponded = result;
-	BTE_ApplyPatch(__wpad_patch_finished);
-
+	u32 i, j, level;
+	
+	WIIUSE_DEBUG("__readlinkkey_finished(%d)",result);
+	
+	_CPU_ISR_Disable(level);
+	if(__wpads_inited==WPAD_STATE_ENABLING) {
+		__wpads_bonded = result;
+ 
+		for(i=0;i<__wpad_guests.num_guests;i++) {
+			BD_ADDR_FROM_BYTES(&__wpad_guest_keys[i].bdaddr, __wpad_guests.guests[i].bdaddr);
+			u8 *src = __wpad_guests.guests[i].link_key;
+			u8 *dst = __wpad_guest_keys[i].key;
+			
+			// Keys are stored in config backwards, like bdaddrs
+			for (j=0;j<BD_LINK_KEY_LEN;j++) {
+				dst[j] = src[BD_LINK_KEY_LEN - 1 - j];
+			}
+		}
+		BTE_ApplyPatch(__wpad_patch_finished);
+	}
+	_CPU_ISR_Restore(level);
 	return ERR_OK;
 }
 
 static s32 __initcore_finished(s32 result,void *usrdata)
 {
-	//printf("__initcore_finished(%d)\n",result);
-
-	if(result==ERR_OK) {
-		BTE_ReadStoredLinkKey(__wpad_keys,WPAD_MAX_WIIMOTES,__readlinkkey_finished);
+	u32 level;
+	
+	WIIUSE_DEBUG("__initcore_finished(%d)",result);
+	
+	_CPU_ISR_Disable(level);
+	if((result==ERR_OK) && (__wpads_inited==WPAD_STATE_ENABLING)) {
+		BTE_ReadStoredLinkKey(__wpad_keys,CONF_PAD_MAX_REGISTERED,__readlinkkey_finished);
 	}
+	_CPU_ISR_Restore(level);
 	return ERR_OK;
 }
 
 static s32 __wpad_disconnect(struct _wpad_cb *wpdcb)
 {
 	struct wiimote_t *wm;
+
+	WIIUSE_DEBUG("__wpad_disconnect");
 
 	if(wpdcb==NULL) return 0;
 
@@ -328,6 +492,7 @@ static void __wpad_calc_data(WPADData *data,WPADData *lstate,struct accel_t *acc
 	data->ir.error_cnt = lstate->ir.error_cnt;
 	data->ir.glitch_cnt = lstate->ir.glitch_cnt;
 
+	data->btns_l = lstate->btns_h;
 	if(data->data_present & WPAD_DATA_ACCEL) {
 		calculate_orientation(accel_calib, &data->accel, &data->orient, smoothed);
 		calculate_gforce(accel_calib, &data->accel, &data->gforce);
@@ -345,7 +510,7 @@ static void __wpad_calc_data(WPADData *data,WPADData *lstate,struct accel_t *acc
 				calc_joystick_state(&nc->js,nc->js.pos.x,nc->js.pos.y);
 				calculate_orientation(&nc->accel_calib,&nc->accel,&nc->orient,smoothed);
 				calculate_gforce(&nc->accel_calib,&nc->accel,&nc->gforce);
-				data->btns_h |= (nc->btns<<16);
+				data->btns_h |= (data->exp.nunchuk.btns<<16);
 			}
 			break;
 
@@ -357,7 +522,12 @@ static void __wpad_calc_data(WPADData *data,WPADData *lstate,struct accel_t *acc
 				cc->l_shoulder = ((f32)cc->ls_raw/0x1F);
 				calc_joystick_state(&cc->ljs, cc->ljs.pos.x, cc->ljs.pos.y);
 				calc_joystick_state(&cc->rjs, cc->rjs.pos.x, cc->rjs.pos.y);
-				data->btns_h |= (cc->btns<<16);
+
+				// overwrite Wiimote buttons (unused) with extra Wii U Pro Controller stick buttons
+				if (data->exp.classic.type == CLASSIC_TYPE_WIIU)
+					data->btns_h = (data->exp.classic.btns & WII_U_PRO_CTRL_BUTTON_EXTRA) >> 16;
+
+				data->btns_h |= ((data->exp.classic.btns & CLASSIC_CTRL_BUTTON_ALL)<<16);
 			}
 			break;
 
@@ -389,7 +559,7 @@ static void __wpad_calc_data(WPADData *data,WPADData *lstate,struct accel_t *acc
 
 				gh3->whammy_bar = (gh3->wb_raw - GUITAR_HERO_3_WHAMMY_BAR_MIN) / (float)(GUITAR_HERO_3_WHAMMY_BAR_MAX - GUITAR_HERO_3_WHAMMY_BAR_MIN);
 				calc_joystick_state(&gh3->js, gh3->js.pos.x, gh3->js.pos.y);
-				data->btns_h |= (gh3->btns<<16);
+				data->btns_h |= (data->exp.gh3.btns<<16);
 			}
 			break;
 
@@ -404,7 +574,6 @@ static void __wpad_calc_data(WPADData *data,WPADData *lstate,struct accel_t *acc
 				break;
 		}
 	}
-	data->btns_l = lstate->btns_h;
 	data->btns_d = data->btns_h & ~data->btns_l;
 	data->btns_u = ~data->btns_h & data->btns_l;
 	*lstate = *data;
@@ -627,30 +796,428 @@ static void __wpad_eventCB(struct wiimote_t *wm,s32 event)
 			memset(&wpaddata[chan],0,sizeof(WPADData));
 			memset(wpdcb->queue_int,0,(sizeof(WPADData)*EVENTQUEUE_LENGTH));
 			__wpads_active &= ~(0x01<<chan);
-			__wpads_used &= ~(0x01<<chan);
+			break;
+		case WIIUSE_ACK:
 			break;
 		default:
+			WIIUSE_DEBUG("__wpad_eventCB(%02x)\n", event);
 			break;
-	}
+		}
 }
 
-void __wpad_disconnectCB(struct bd_addr *offaddr, u8 reason)
+void __wpad_disconnectCB(struct bd_addr *pad_addr, u8 reason)
 {
-	struct bd_addr bdaddr;
 	int i;
+	u32 level;
+	
+	WIIUSE_DEBUG("__wpad_disconnectCB(%d)", reason);
 
+	_CPU_ISR_Disable(level);
 	if(__wpads_inited == WPAD_STATE_ENABLED) {
-        for(i=0;i<__wpad_devs.num_registered;i++) {
-            BD_ADDR(&(bdaddr),__wpad_devs.registered[i].bdaddr[5],__wpad_devs.registered[i].bdaddr[4],__wpad_devs.registered[i].bdaddr[3],__wpad_devs.registered[i].bdaddr[2],__wpad_devs.registered[i].bdaddr[1],__wpad_devs.registered[i].bdaddr[0]);
-			if(bd_addr_cmp(offaddr,&bdaddr)) {
-				if(reason == DISCONNECT_BATTERY_DIED) {
-					if(__wpad_batcb) __wpad_batcb(i);		//sanity check since this pointer can be NULL.
-				} else if(reason == DISCONNECT_POWER_OFF)
-					__wpad_powcb(i);						//no sanity check because there's a default callback iff not otherwise set.
+		for(i=0;i<WPAD_MAX_DEVICES;i++) {
+			if(bd_addr_cmp(pad_addr,&__wpads_listen[i].bdaddr)) {
+				if (__wpad_disconncb) {
+					__wpad_disconncb(i, reason);
+				} else {
+					// For backwards compatibility
+					switch (reason) {
+						case WPAD_DISCON_BATTERY_DIED:
+							if(__wpad_batcb) __wpad_batcb(i);
+							break;
+						case WPAD_DISCON_POWER_OFF:
+							if(__wpad_powcb) __wpad_powcb(i);
+							break;
+					}
+				}
+				__wpads_used &= ~(0x01<<i);
 				break;
 			}
 		}
 	}
+	_CPU_ISR_Restore(level);
+}
+
+static void __wpad_hostsyncbuttonCB(u32 held)
+{
+	u32 level;
+	
+	_CPU_ISR_Disable(level);
+	if((__wpads_inited == WPAD_STATE_ENABLED) && __wpad_hostsynccb) {
+		__wpad_hostsynccb(held);
+	}
+	_CPU_ISR_Restore(level);
+}
+
+static s32 GetActiveSlot(struct bd_addr *pad_addr)
+{
+	int i;
+	int slot = CONF_PAD_MAX_ACTIVE;
+	struct bd_addr bdaddr;
+
+	for(i=0; i<CONF_PAD_MAX_ACTIVE; i++) {
+		BD_ADDR_FROM_BYTES(&bdaddr,__wpad_devs.active[i].bdaddr);
+		if(bd_addr_cmp(pad_addr,&bdaddr)) {
+			slot = i;
+			break;
+		}
+	}
+
+	return slot;
+}
+
+s32 __wpad_read_remote_name_finished(s32 result,void *userdata)
+{
+	u32 level;
+	int i;
+	struct bd_addr bdaddr;
+	int slot = WPAD_MAX_DEVICES;
+	struct pad_name_info *info = (struct pad_name_info *)userdata;
+
+	_CPU_ISR_Disable(level);
+
+	if(result == ERR_OK && info != NULL) {
+		if (!strncmp("Nintendo RVL-", (char *)info->name, 13)) {
+			// Found Wii accessory, is it controller or something else?
+			if (!strncmp("Nintendo RVL-CNT-", (char *)info->name, 17)) {
+				slot = GetActiveSlot(&info->bdaddr);
+				if (slot < CONF_PAD_MAX_ACTIVE) {
+					WIIUSE_DEBUG("Wiimote already active in slot %d", slot);
+				} else {
+					// Not active, try to make active
+					slot = WPAD_MAX_DEVICES;
+					for(i=0; i<CONF_PAD_MAX_ACTIVE; i++) {
+						if(!(__wpads_used & (1<<i))) {
+							WIIUSE_DEBUG("Attempting to connect to Wiimote using slot %d", i);
+							slot = i;
+							break;
+						}
+					}
+				}
+			} else {
+				// Check for balance board
+				BD_ADDR_FROM_BYTES(&(bdaddr),__wpad_devs.balance_board.bdaddr);
+				if (bd_addr_cmp(&info->bdaddr,&bdaddr)) {
+					WIIUSE_DEBUG("Balance Board already registered");
+					slot = WPAD_BALANCE_BOARD;
+				}
+				
+				// Not active, try to make active
+				if(slot != WPAD_BALANCE_BOARD) {
+					if(!(__wpads_used & (1<<WPAD_BALANCE_BOARD))) {
+						WIIUSE_DEBUG("Attempting to connect to Balance Board");
+						slot = WPAD_BALANCE_BOARD;
+					}
+				}
+			}
+
+			if(slot < WPAD_MAX_DEVICES) {
+				result = wiiuse_connect(&__wpads_listen[slot],&info->bdaddr,info->name,__wpad_register_new);
+				__wpads_used |= (0x01<<slot);
+				result = ERR_OK;
+			} else {
+				WIIUSE_WARNING("WPAD All Slots Used\n");
+				result = ERR_CONN;
+			}
+		} else {
+			result = ERR_ARG;
+		}
+	}
+
+	if (info) free(info);
+	_CPU_ISR_Restore(level);
+
+	return result;
+}
+
+static s32 GetRegisteredSlot(struct bd_addr *pad_addr)
+{
+	int i;
+	int slot = CONF_PAD_MAX_REGISTERED;
+	struct bd_addr bdaddr;
+
+	for(i=0; i<__wpad_devs.num_registered; i++) {
+		BD_ADDR_FROM_BYTES(&bdaddr,__wpad_devs.registered[i].bdaddr);
+		if(bd_addr_cmp(pad_addr,&bdaddr)) {
+			slot = i;
+			break;
+		}
+	}
+
+	return slot;
+}
+
+static s32 GetGuestSlot(struct bd_addr *pad_addr)
+{
+	int i;
+	int slot = CONF_PAD_MAX_ACTIVE;
+	struct bd_addr bdaddr;
+
+	for(i=0; i<__wpad_guests.num_guests; i++) {
+		BD_ADDR_FROM_BYTES(&bdaddr,__wpad_guests.guests[i].bdaddr);
+		if(bd_addr_cmp(pad_addr,&bdaddr)) {
+			slot = i;
+			break;
+		}
+	}
+
+	return slot;
+}
+
+static s8 __wpad_connreqCB(void *arg,struct bd_addr *pad_addr,u8 *cod,u8 link_type)
+{
+	int i, j, level;
+	int slot = WPAD_MAX_DEVICES;
+	int confslot = CONF_PAD_MAX_ACTIVE;
+	struct bd_addr bdaddr;
+	const u8 *name = NULL;
+
+	WIIUSE_DEBUG("__wpad_connreqCB");
+	_CPU_ISR_Disable(level);
+
+	// Only accept connection requests (i.e. "press any button") if not doing guest pairing
+	if(BTE_GetPairMode() == PAIR_MODE_NORMAL) {
+		if(!bd_addr_cmp(pad_addr,BD_ADDR_ANY)) {
+			confslot = GetActiveSlot(pad_addr);
+			if (confslot < CONF_PAD_MAX_ACTIVE) {
+				BD_ADDR_FROM_BYTES(&bdaddr,__wpad_devs.active[confslot].bdaddr);
+				name = (const u8 *)__wpad_devs.active[confslot].name;
+				WIIUSE_DEBUG("Active pad '%s' found in slot %d", name, confslot);
+				if (!(__wpads_used & (1<<confslot)) || bd_addr_cmp(pad_addr,&bdaddr))
+					slot = confslot;
+				else
+					WIIUSE_DEBUG("Slot %d taken! Finding new slot", confslot);
+			}
+	
+			if(slot >= WPAD_MAX_DEVICES) {
+				for(i=0; i<CONF_PAD_MAX_REGISTERED; i++) {
+					BD_ADDR_FROM_BYTES(&bdaddr,__wpad_devs.registered[i].bdaddr);
+					if(bd_addr_cmp(pad_addr,&bdaddr)) {
+						name = (const u8 *)__wpad_devs.registered[i].name;
+						WIIUSE_DEBUG("Registered pad '%s' found in slot %d", name, i);
+		
+						// Not active, try to make active
+						if(!strncmp("Nintendo RVL-CNT-", __wpad_devs.registered[i].name, 17)) {
+							for(j=0; j<WPAD_BALANCE_BOARD; j++) {
+								if(!(__wpads_used & (1<<j))) {
+									WIIUSE_DEBUG("Attempting to accept connection from pad using slot %d", j);
+									slot = j;
+									break;
+								}
+							}
+
+							if(slot >= WPAD_BALANCE_BOARD) {
+								slot = WPAD_MAX_DEVICES;
+							}
+						} else {
+							if(!(__wpads_used & (1<<WPAD_BALANCE_BOARD))) {
+								WIIUSE_DEBUG("Attempting to accept connection from Balance Board");
+								slot = WPAD_BALANCE_BOARD;
+								break;
+							}
+						}
+						break;
+					}
+				}
+			}
+
+			if(slot < WPAD_MAX_DEVICES) {
+				__wpads_used |= (0x01<<slot);
+				WIIUSE_DEBUG("Assigning slot %d",slot);
+
+				wiiuse_accept(&__wpads_listen[slot],pad_addr,name,__wpad_assign_slot);
+				_CPU_ISR_Restore(level);
+				return ERR_OK;
+			}
+		}
+
+		_CPU_ISR_Restore(level);
+		return ERR_VAL;
+	}
+	_CPU_ISR_Restore(level);
+	return ERR_CONN;
+}
+
+static s8 __wpad_linkkeyreqCB(void *arg,struct bd_addr *pad_addr)
+{
+	bool found = false;
+	int i;
+	
+	WIIUSE_DEBUG("__wpad_linkkeyreqCB");
+	
+	for(i=0; i<__wpads_bonded; i++) {
+		if(bd_addr_cmp(pad_addr,&__wpad_keys[i].bdaddr)) {
+			found = true;
+			BTE_LinkKeyRequestReply(pad_addr,__wpad_keys[i].key);
+			break;
+		}
+	}
+
+	if(!found) {
+		for(i=0; i<CONF_PAD_MAX_ACTIVE; i++) {
+			if(bd_addr_cmp(pad_addr,&__wpad_guest_keys[i].bdaddr)) {
+				found = true;
+				BTE_LinkKeyRequestReply(pad_addr,__wpad_guest_keys[i].key);
+				break;
+			}
+		}
+	}
+
+	if(!found)
+		BTE_LinkKeyRequestNegativeReply(pad_addr);
+
+	return ERR_OK;
+}
+
+static s8 __wpad_linkkeynotCB(void *arg,struct bd_addr *pad_addr,u8 *key)
+{
+	int i;
+
+	WIIUSE_DEBUG("__wpad_linkkeynotCB");
+		
+	if(BTE_GetPairMode() == PAIR_MODE_NORMAL) {
+		// Only write link key to controller if not doing guest pairing
+		BTE_WriteStoredLinkKey(pad_addr,key);
+
+		for(i=0; i<CONF_PAD_MAX_REGISTERED; i++) {
+			// Old device, new key
+			if(bd_addr_cmp(pad_addr,&__wpad_keys[i].bdaddr)) {
+				memcpy(__wpad_keys[i].key,key,sizeof(__wpad_keys[i].key));
+				break;
+			}
+			
+			// New device
+			if(bd_addr_cmp(BD_ADDR_ANY,&__wpad_keys[i].bdaddr)) {
+				bd_addr_set(&__wpad_keys[i].bdaddr,pad_addr);
+				memcpy(__wpad_keys[i].key,key,sizeof(__wpad_keys[i].key));
+				__wpads_bonded++;
+				break;
+			}
+		}
+	} else {
+		for(i=0; i<CONF_PAD_ACTIVE_AND_OTHER; i++) {
+			// Old device, new key
+			if(bd_addr_cmp(pad_addr,&__wpad_guest_keys[i].bdaddr)) {
+				memcpy(__wpad_guest_keys[i].key,key,sizeof(__wpad_guest_keys[i].key));
+				break;
+			}
+			
+			// New device
+			if(bd_addr_cmp(BD_ADDR_ANY,&__wpad_guest_keys[i].bdaddr)) {
+				bd_addr_set(&__wpad_guest_keys[i].bdaddr,pad_addr);
+				memcpy(__wpad_guest_keys[i].key,key,sizeof(__wpad_guest_keys[i].key));
+				break;
+			}
+		}
+	}
+
+	return ERR_OK;
+}
+
+s32 __wpad_inquiry_finished(s32 result,void *userdata)
+{
+	int i;
+	struct pad_name_info *padinfo;
+	struct bte_inquiry_res *inq_res = (struct bte_inquiry_res *)userdata;
+
+	if(result == ERR_OK && inq_res != NULL) {
+		// Filter out weird null values
+		for(i=0;i<inq_res->count;i++) {
+			struct inquiry_info_ex *info = &inq_res->info[i];
+
+			if(!bd_addr_cmp(&info->bdaddr,BD_ADDR_ANY)) {
+				// Read name of first valid device
+				padinfo = (struct pad_name_info *)malloc(sizeof(struct pad_name_info));
+				if (padinfo == NULL)
+					return ERR_MEM;
+				bd_addr_set(&padinfo->bdaddr, &info->bdaddr);
+				BTE_ReadRemoteName(padinfo, __wpad_read_remote_name_finished);
+				break;
+			}
+		}
+	}
+
+	return ERR_OK;
+}
+
+s32 WPAD_StartPairing(void)
+{
+	u32 level;
+	
+	_CPU_ISR_Disable(level);
+	WIIUSE_INFO("WPAD Begin Pairing");
+	BTE_Inquiry(BD_MAX_INQUIRY_DEVS, TRUE, __wpad_inquiry_finished);
+	_CPU_ISR_Restore(level);
+
+	return ERR_OK;
+}
+
+s32 WPAD_WipeSavedControllers(void)
+{
+	u32 level;
+	int i;
+
+	_CPU_ISR_Disable(level);
+	WIIUSE_DEBUG("WPAD Wipe Registered Pads");
+
+	for(i=0;i<WPAD_MAX_DEVICES;i++) {
+		__wpad_disconnect(&__wpdcb[i]);
+		memset(__wpads_listen[i].name, 0, sizeof(__wpads_listen[i].name));
+	}
+
+	__wpads_active = 0;
+	__wpads_used = 0;
+	__wpads_bonded = 0;
+	memset(&__wpad_devs,0,sizeof(__wpad_devs));
+	memset(&__wpad_guests,0,sizeof(__wpad_guests));
+	memset(__wpad_keys,0,sizeof(__wpad_keys));
+	memset(__wpad_guest_keys,0,sizeof(__wpad_guest_keys));
+	BTE_ClearStoredLinkKeys();
+	_CPU_ISR_Restore(level);
+
+	return ERR_OK;
+}
+
+void __wpad_def_hostsynccb(u32 held)
+{
+	if(held)
+		WPAD_WipeSavedControllers();
+	else
+		WPAD_StartPairing();
+}
+
+s32 WPAD_Search(void)
+{
+	u32 level;
+	int i;
+
+	_CPU_ISR_Disable(level);
+	WIIUSE_INFO("WPAD Guest Device Search");
+
+	for(i=0;i<WPAD_MAX_DEVICES;i++) {
+		__wpad_disconnect(&__wpdcb[i]);
+		memset(__wpads_listen[i].name, 0, sizeof(__wpads_listen[i].name));
+	}
+	__wpads_active = 0;
+	__wpads_used = 0;
+	memset(__wpad_devs.active,0,sizeof(__wpad_devs.active));
+	memset(&__wpad_guests,0,sizeof(__wpad_guests));
+	memset(__wpad_guest_keys,0,sizeof(__wpad_guest_keys));
+
+	BTE_PeriodicInquiry(BD_MAX_INQUIRY_DEVS, TRUE, __wpad_inquiry_finished);
+	_CPU_ISR_Restore(level);
+
+	return ERR_OK;
+}
+
+s32 WPAD_StopSearch(void)
+{
+	u32 level;
+
+	_CPU_ISR_Disable(level);
+	WIIUSE_DEBUG("WPAD Stopping Guest Device Search");
+	BTE_ExitPeriodicInquiry();
+	_CPU_ISR_Restore(level);
+	return ERR_OK;
 }
 
 s32 WPAD_Init(void)
@@ -661,14 +1228,17 @@ s32 WPAD_Init(void)
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
-		__wpads_ponded = 0;
+		__wpads_bonded = 0;
 		__wpads_active = 0;
 
-		memset(__wpdcb,0,sizeof(struct _wpad_cb)*WPAD_MAX_WIIMOTES);
-		memset(&__wpad_devs,0,sizeof(conf_pads));
-		memset(__wpad_keys,0,sizeof(struct linkkey_info)*WPAD_MAX_WIIMOTES);
+		WIIUSE_DEBUG("WPAD_Init");
 
-		for(i=0;i<WPAD_MAX_WIIMOTES;i++) {
+		memset(__wpdcb,0,sizeof(__wpdcb));
+		memset(&__wpad_devs,0,sizeof(conf_pads));
+		memset(__wpad_keys,0,sizeof(__wpad_keys));
+		memset(__wpad_guest_keys,0,sizeof(__wpad_guest_keys));
+
+		for(i=0;i<WPAD_MAX_DEVICES;i++) {
 			__wpdcb[i].thresh.btns = WPAD_THRESH_DEFAULT_BUTTONS;
 			__wpdcb[i].thresh.ir = WPAD_THRESH_DEFAULT_IR;
 			__wpdcb[i].thresh.acc = WPAD_THRESH_DEFAULT_ACCEL;
@@ -690,19 +1260,32 @@ s32 WPAD_Init(void)
 			return WPAD_ERR_BADCONF;
 		}
 
-		if(__wpad_devs.num_registered == 0) {
-			WPAD_Shutdown();
-			_CPU_ISR_Restore(level);
-			return WPAD_ERR_NONEREGISTERED;
-		}
-
 		if(__wpad_devs.num_registered > CONF_PAD_MAX_REGISTERED) {
 			WPAD_Shutdown();
 			_CPU_ISR_Restore(level);
 			return WPAD_ERR_BADCONF;
 		}
 
-		__wpads = wiiuse_init(WPAD_MAX_WIIMOTES,__wpad_eventCB);
+		if(CONF_GetPadGuestDevices(&__wpad_guests) < 0) {
+			WPAD_Shutdown();
+			_CPU_ISR_Restore(level);
+			return WPAD_ERR_BADCONF;
+		}
+
+		if(__wpad_guests.num_guests > CONF_PAD_MAX_ACTIVE) {
+			WPAD_Shutdown();
+			_CPU_ISR_Restore(level);
+			return WPAD_ERR_BADCONF;
+		}
+
+		// Clear guest devices after loading so guests are unregistered in case of unexpected shutdown
+		if(CONF_SetPadGuestDevices(NULL) < 0) {
+			WPAD_Shutdown();
+			_CPU_ISR_Restore(level);
+			return WPAD_ERR_BADCONF;
+		}
+
+		__wpads = wiiuse_init(WPAD_MAX_DEVICES,__wpad_eventCB);
 		if(__wpads==NULL) {
 			WPAD_Shutdown();
 			_CPU_ISR_Restore(level);
@@ -711,8 +1294,14 @@ s32 WPAD_Init(void)
 
 		__wiiuse_sensorbar_enable(1);
 
+		__wpads_inited = WPAD_STATE_ENABLING;
+
 		BTE_Init();
 		BTE_SetDisconnectCallback(__wpad_disconnectCB);
+		BTE_SetHostSyncButtonCallback(__wpad_hostsyncbuttonCB);
+		BTE_SetConnectionRequestCallback(__wpad_connreqCB);
+		BTE_SetLinkKeyRequestCallback(__wpad_linkkeyreqCB);
+		BTE_SetLinkKeyNotificationCallback(__wpad_linkkeynotCB);
 		BTE_InitCore(__initcore_finished);
 
 		if (SYS_CreateAlarm(&__wpad_timer) < 0)
@@ -727,7 +1316,18 @@ s32 WPAD_Init(void)
 		tb.tv_sec = 1;
 		tb.tv_nsec = 0;
 		SYS_SetPeriodicAlarm(__wpad_timer,&tb,&tb,__wpad_timeouthandler,NULL);
-		__wpads_inited = WPAD_STATE_ENABLING;
+
+		if (LWP_SemInit(&__wpad_confsave_sem,0,1)<0) {
+			WPAD_Shutdown();
+			_CPU_ISR_Restore(level);
+			return WPAD_ERR_UNKNOWN;
+		}
+		
+		if(LWP_CreateThread(&__wpad_confsave_thread,__wpad_confsave_thread_func,NULL,NULL,0,80)<0) {
+			WPAD_Shutdown();
+			_CPU_ISR_Restore(level);
+			return WPAD_ERR_UNKNOWN;
+		}
 	}
 	_CPU_ISR_Restore(level);
 	return WPAD_ERR_NONE;
@@ -741,7 +1341,7 @@ s32 WPAD_ReadEvent(s32 chan, WPADData *data)
 	struct _wpad_cb *wpdcb = NULL;
 	WPADData *lstate = NULL,*wpadd = NULL;
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -794,7 +1394,7 @@ s32 WPAD_DroppedEvents(s32 chan)
 	int dropped = 0;
 
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_DroppedEvents(i)) < WPAD_ERR_NONE)
 				return ret;
 			else
@@ -802,7 +1402,7 @@ s32 WPAD_DroppedEvents(s32 chan)
 		return dropped;
 	}
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -824,7 +1424,7 @@ s32 WPAD_Flush(s32 chan)
 	int i;
 	int count = 0;
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_Flush(i)) < WPAD_ERR_NONE)
 				return ret;
 			else
@@ -851,7 +1451,7 @@ s32 WPAD_ReadPending(s32 chan, WPADDataCallback datacb)
 	s32 ret;
 
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_ReadPending(i, datacb)) >= WPAD_ERR_NONE)
 				count += ret;
 		return count;
@@ -907,13 +1507,13 @@ s32 WPAD_SetDataFormat(s32 chan, s32 fmt)
 	int i;
 
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_SetDataFormat(i, fmt)) < WPAD_ERR_NONE)
 				return ret;
 		return WPAD_ERR_NONE;
 	}
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -945,13 +1545,13 @@ s32 WPAD_SetMotionPlus(s32 chan, u8 enable)
 	int i;
 	
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_SetMotionPlus(i, enable)) < WPAD_ERR_NONE)
 				return ret;
 		return WPAD_ERR_NONE;
 	}
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -973,13 +1573,13 @@ s32 WPAD_SetVRes(s32 chan,u32 xres,u32 yres)
 	int i;
 
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_SetVRes(i, xres, yres)) < WPAD_ERR_NONE)
 				return ret;
 		return WPAD_ERR_NONE;
 	}
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -1012,7 +1612,7 @@ s32 WPAD_Probe(s32 chan,u32 *type)
 	u32 level,dev;
 	wiimote *wm = NULL;
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -1050,7 +1650,7 @@ s32 WPAD_SetEventBufs(s32 chan, WPADData *bufs, u32 cnt)
 	u32 level;
 	struct _wpad_cb *wpdcb = NULL;
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	wpdcb = &__wpdcb[chan];
@@ -1063,6 +1663,7 @@ s32 WPAD_SetEventBufs(s32 chan, WPADData *bufs, u32 cnt)
 	return WPAD_ERR_NONE;
 }
 
+[[deprecated]]
 void WPAD_SetPowerButtonCallback(WPADShutdownCallback cb)
 {
 	u32 level;
@@ -1075,6 +1676,7 @@ void WPAD_SetPowerButtonCallback(WPADShutdownCallback cb)
 	_CPU_ISR_Restore(level);
 }
 
+[[deprecated]]
 void WPAD_SetBatteryDeadCallback(WPADShutdownCallback cb)
 {
 	u32 level;
@@ -1084,58 +1686,99 @@ void WPAD_SetBatteryDeadCallback(WPADShutdownCallback cb)
 	_CPU_ISR_Restore(level);
 }
 
+void WPAD_SetDisconnectCallback(WPADDisconnectCallback cb)
+{
+	u32 level;
+
+	_CPU_ISR_Disable(level);
+	__wpad_disconncb = cb;
+	_CPU_ISR_Restore(level);
+}
+
+void WPAD_SetHostSyncButtonCallback(WPADHostSyncBtnCallback cb)
+{
+	u32 level;
+
+	_CPU_ISR_Disable(level);
+	if(cb)
+		__wpad_hostsynccb = cb;
+	else
+		__wpad_hostsynccb = __wpad_def_hostsynccb;
+	_CPU_ISR_Restore(level);
+}
+
+void WPAD_SetStatusCallback(WPADStatusCallback cb)
+{
+	u32 level;
+
+	_CPU_ISR_Disable(level);
+	__wpad_statuscb = cb;
+	_CPU_ISR_Restore(level);
+}
+
 s32 WPAD_Disconnect(s32 chan)
 {
+	s32 err = WPAD_ERR_NONE;
 	u32 level, cnt = 0;
 	struct _wpad_cb *wpdcb = NULL;
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
-	if(__wpads_inited==WPAD_STATE_DISABLED) {
+	if(__wpads_inited==WPAD_STATE_ENABLED) {
+		wpdcb = &__wpdcb[chan];
+		__wpad_disconnect(wpdcb);
+
 		_CPU_ISR_Restore(level);
-		return WPAD_ERR_NOT_READY;
+
+		while(__wpads_used&(0x01<<chan)) {
+			usleep(50);
+			if(++cnt > 3000) break;
+		}
+	} else {
+		_CPU_ISR_Restore(level);
+		err = WPAD_ERR_NOT_READY;
 	}
 
-	wpdcb = &__wpdcb[chan];
-	__wpad_disconnect(wpdcb);
-
-	_CPU_ISR_Restore(level);
-
-	while(__wpads_active&(0x01<<chan)) {
-		usleep(50);
-		if(++cnt > 3000) break;
-	}
-
-	return WPAD_ERR_NONE;
+	return err;
 }
 
-void WPAD_Shutdown(void)
+s32 WPAD_Shutdown(void)
 {
+	s32 err = WPAD_ERR_NONE;
 	s32 i;
 	u32 level;
-	u32 cnt = 0;
 	struct _wpad_cb *wpdcb = NULL;
-
+	
+	WIIUSE_DEBUG("WPAD_Shutdown");
+	
 	_CPU_ISR_Disable(level);
+	BTE_Close();
+
+	__wpad_confsave_thread_stop();
+	if(__wpads_inited!=WPAD_STATE_DISABLED) {
+		CONF_SetPadGuestDevices(&__wpad_guests);
+		CONF_SaveChanges();
+	}
 
 	__wpads_inited = WPAD_STATE_DISABLED;
 	SYS_RemoveAlarm(__wpad_timer);
-	for(i=0;i<WPAD_MAX_WIIMOTES;i++) {
+	for(i=0;i<WPAD_MAX_DEVICES;i++) {
 		wpdcb = &__wpdcb[i];
 		SYS_RemoveAlarm(wpdcb->sound_alarm);
-		__wpad_disconnect(wpdcb);
+		bte_free(__wpads_listen[i].sock);
+		__wpads_listen[i].sock = NULL;
 	}
+
+	__wpads_active = 0;
+	__wpads_used = 0;
 
 	__wiiuse_sensorbar_enable(0);
 	_CPU_ISR_Restore(level);
 
-	while(__wpads_active) {
-		usleep(50);
-		if(++cnt > 3000) break;
-	}
-
 	BTE_Shutdown();
+
+	return err;
 }
 
 void WPAD_SetIdleTimeout(u32 seconds)
@@ -1159,13 +1802,13 @@ s32 WPAD_Rumble(s32 chan, int status)
 	u32 level;
 
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_Rumble(i,status)) < WPAD_ERR_NONE)
 				return ret;
 		return WPAD_ERR_NONE;
 	}
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -1187,13 +1830,13 @@ s32 WPAD_SetIdleThresholds(s32 chan, s32 btns, s32 ir, s32 accel, s32 js, s32 wb
 	u32 level;
 
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_SetIdleThresholds(i,btns,ir,accel,js,wb,mp)) < WPAD_ERR_NONE)
 				return ret;
 		return WPAD_ERR_NONE;
 	}
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -1213,34 +1856,6 @@ s32 WPAD_SetIdleThresholds(s32 chan, s32 btns, s32 ir, s32 accel, s32 js, s32 wb
 	return WPAD_ERR_NONE;
 }
 
-s32 WPAD_ControlLed(s32 chan,s32 leds)
-{
-	int i;
-	s32 ret;
-	u32 level;
-
-	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
-			if((ret = WPAD_ControlLed(i,leds)) < WPAD_ERR_NONE)
-				return ret;
-		return WPAD_ERR_NONE;
-	}
-
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
-
-	_CPU_ISR_Disable(level);
-	if(__wpads_inited==WPAD_STATE_DISABLED) {
-		_CPU_ISR_Restore(level);
-		return WPAD_ERR_NOT_READY;
-	}
-
-	if(__wpads[chan]!=NULL)
-		wiiuse_set_leds(__wpads[chan],(leds<<4)&0xf0,NULL);
-
-	_CPU_ISR_Restore(level);
-	return WPAD_ERR_NONE;
-}
-
 s32 WPAD_ControlSpeaker(s32 chan,s32 enable)
 {
 	int i;
@@ -1248,13 +1863,13 @@ s32 WPAD_ControlSpeaker(s32 chan,s32 enable)
 	u32 level;
 
 	if(chan == WPAD_CHAN_ALL) {
-		for(i=WPAD_CHAN_0; i<WPAD_MAX_WIIMOTES; i++)
+		for(i=WPAD_CHAN_0; i<WPAD_MAX_DEVICES; i++)
 			if((ret = WPAD_ControlSpeaker(i,enable)) < WPAD_ERR_NONE)
 				return ret;
 		return WPAD_ERR_NONE;
 	}
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -1277,7 +1892,7 @@ s32 WPAD_IsSpeakerEnabled(s32 chan)
 	u32 level;
 	wiimote *wm = NULL;
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -1302,7 +1917,7 @@ s32 WPAD_SendStreamData(s32 chan,void *buf,u32 len)
 	struct timespec tb;
 	wiimote *wm = NULL;
 
-	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_WIIMOTES) return WPAD_ERR_BAD_CHANNEL;
+	if(chan<WPAD_CHAN_0 || chan>=WPAD_MAX_DEVICES) return WPAD_ERR_BAD_CHANNEL;
 
 	_CPU_ISR_Disable(level);
 	if(__wpads_inited==WPAD_STATE_DISABLED) {
@@ -1348,60 +1963,93 @@ void WPAD_EncodeData(WPADEncStatus *info,u32 flag,const s16 *pcmSamples,s32 numS
 
 WPADData *WPAD_Data(int chan)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES) return NULL;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES) return NULL;
 	return &wpaddata[chan];
 }
 
 u8 WPAD_BatteryLevel(int chan)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES) return 0;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES) return 0;
 	return wpaddata[chan].battery_level;
 }
 
 u32 WPAD_ButtonsUp(int chan)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES) return 0;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES) return 0;
 	return wpaddata[chan].btns_u;
 }
 
 u32 WPAD_ButtonsDown(int chan)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES) return 0;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES) return 0;
 	return wpaddata[chan].btns_d;
 }
 
 u32 WPAD_ButtonsHeld(int chan)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES) return 0;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES) return 0;
 	return wpaddata[chan].btns_h;
 }
 
 void WPAD_IR(int chan, struct ir_t *ir)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES || ir==NULL ) return;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES || ir==NULL ) return;
 	*ir = wpaddata[chan].ir;
 }
 
 void WPAD_Orientation(int chan, struct orient_t *orient)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES || orient==NULL ) return;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES || orient==NULL ) return;
 	*orient = wpaddata[chan].orient;
 }
 
 void WPAD_GForce(int chan, struct gforce_t *gforce)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES || gforce==NULL ) return;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES || gforce==NULL ) return;
 	*gforce = wpaddata[chan].gforce;
 }
 
 void WPAD_Accel(int chan, struct vec3w_t *accel)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES || accel==NULL ) return;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES || accel==NULL ) return;
 	*accel = wpaddata[chan].accel;
 }
 
 void WPAD_Expansion(int chan, struct expansion_t *exp)
 {
-	if(chan<0 || chan>=WPAD_MAX_WIIMOTES || exp==NULL ) return;
+	if(chan<0 || chan>=WPAD_MAX_DEVICES || exp==NULL ) return;
 	*exp = wpaddata[chan].exp;
+}
+
+void __wpad_status_finished(struct wiimote_t *wm,ubyte *data,uword len)
+{
+	u32 level;
+
+	_CPU_ISR_Disable(level);
+	if (wm && __wpad_statuscb) __wpad_statuscb(wm->unid);
+	_CPU_ISR_Restore(level);
+}
+
+void WPAD_PadStatus(int chan)
+{
+	u32 level;
+
+	_CPU_ISR_Disable(level);
+	if(chan<0 || chan>=WPAD_MAX_DEVICES) return;
+	if(__wpads[chan] && WIIMOTE_IS_SET(__wpads[chan],WIIMOTE_STATE_CONNECTED)) wiiuse_status(__wpads[chan], __wpad_status_finished);
+
+	_CPU_ISR_Restore(level);
+}
+
+bool WPAD_IsBatteryCritical(int chan)
+{
+	if(chan<0 || chan>=WPAD_MAX_DEVICES) return false;
+	return WIIMOTE_IS_SET(__wpads[chan],WIIMOTE_STATE_BATTERY_CRITICAL);
+}
+
+int WPAD_HasMotionPlus(s32 chan) {
+    if (__wpads && __wpads[chan]) __wpads[chan]->state &= ~0x000020;
+    if (__wpads == NULL) return 0;
+    if (__wpads[chan] == NULL) return 0;
+    return (__wpads[chan]->state & 0x100000) ? 1 : 0;
 }


### PR DESCRIPTION
Motion Plus has been completely non-functional in libogc since it was first added. After extensive debugging on real Wii hardware, I found and fixed 4 separate bugs that together prevented Motion Plus from ever working in any homebrew application.

## What was broken

Every single homebrew app that ever tried to use Motion Plus got zeros from exp.mp.rx/ry/rz and could never detect if Motion Plus was present. This has been a known unfixed issue since at least 2021 as documented in devkitPro/libogc issue #111.

## Bugs fixed in wiiuse/motion_plus.c

**Bug 1 — Wrong register address:**
wiiuse_probe_motion_plus was reading from WM_EXP_MOTION_PLUS_MODE (0x04A600FE) instead of WM_EXP_ID (0x04A400FA). These are completely different memory banks on the Wiimote. The probe was never reading the actual extension identifier.

**Bug 2 — Wrong read size:**
Only 2 bytes were being read when the Motion Plus identifier is 6 bytes long. This made the data[5] check an out of bounds memory read.

**Bug 3 — Wrong byte index:**
The check was data[1] != 0x05 when it should be data[5] != 0x05. The value 0x05 is the last byte of the 6 byte Motion Plus identifier (00 00 A6 20 00 05), not the second byte.

## Changes to wiiuse/wpad.c

- Removed static from __wpads declaration so it can be accessed externally
- Added WPAD_HasMotionPlus(s32 chan) public function that reads WIIMOTE_STATE_MPLUS_PRESENT flag directly from the internal wiimote struct

## Changes to gc/wiiuse/wpad.h

- Added declaration for WPAD_HasMotionPlus(s32 chan)
- Added WPAD_EXP_MOTION_PLUS constant (value 5) to match existing WPAD_EXP_NUNCHUK and WPAD_EXP_CLASSIC constants

## Additional notes

WIIMOTE_STATE_EXP_HANDSHAKE gets stuck set and prevents subsequent calls to WPAD_SetMotionPlus from doing anything. Callers need to periodically clear this flag before retrying detection. This is documented in the example usage below.

## Tested on

Real Wii hardware with both the original Motion Plus accessory (RVL-026) and a Wiimote Plus with built-in Motion Plus (RVL-CNT-01-TR). Gyro data from exp.mp.rx/ry/rz correctly reflects real sensor movement after these fixes.

## Example usage
```c
// Enable and detect Motion Plus
WPAD_SetMotionPlus(chan, 1);

// Periodically clear stuck handshake flag and retry
if (frame % 10 == 0) {
    if (!(wm->state & WIIMOTE_STATE_MPLUS_PRESENT)) {
        wm->state &= ~WIIMOTE_STATE_EXP_HANDSHAKE;
        WPAD_SetMotionPlus(chan, 1);
    }
}

// Check if detected
if (WPAD_HasMotionPlus(chan)) {
    WPADData *data = WPAD_Data(chan);
    float pitch = (float)data->exp.mp.rx;
    float roll  = (float)data->exp.mp.ry;
    float yaw   = (float)data->exp.mp.rz;
}
```